### PR TITLE
Add required in individual files config-oh-settings and config-file-settings

### DIFF
--- a/project_admin/templates/project_admin/config-file-settings.html
+++ b/project_admin/templates/project_admin/config-file-settings.html
@@ -7,11 +7,11 @@
   {% csrf_token %}
   <div class="form-group">
     <label>File description</label>
-    <input class="form-control" name="file_description" size=60 type="text" value="{{config.file_description}}" placeholder="A description of this file">
+    <input class="form-control" name="file_description" size=60 type="text" value="{{config.file_description}}" placeholder="A description of this file" required>
   </div>
   <div class="form-group">
     <label>File tags (comma separated)</label>
-    <input class="form-control" name="file_tags" type="text" size=60 value="{{tags}}" placeholder="comma, separated, list, of, tags">
+    <input class="form-control" name="file_tags" type="text" size=60 value="{{tags}}" placeholder="comma, separated, list, of, tags" required>
     <p class="help-block">Tags are a good way to describe the files you are uploading</p>
   </div>
   <input type="submit" class="btn btn-default" value="Save updates">

--- a/project_admin/templates/project_admin/config-oh-settings.html
+++ b/project_admin/templates/project_admin/config-oh-settings.html
@@ -6,10 +6,10 @@
 <form action="{% url 'project-admin:config-oh-settings' %}" method="post">
   {% csrf_token %}
   <div class="form-group">
-    <label>Client ID</label> <input class="form-control" name="client_id" size=60 type="text" value="{{config.oh_client_id}}" placeholder="Enter your Open Humans Client-ID">
+    <label>Client ID</label> <input class="form-control" name="client_id" size=60 type="text" value="{{config.oh_client_id}}" placeholder="Enter your Open Humans Client-ID" required>
   </div>
   <div class="form-group">
-    <label>Client secret</label> <input class="form-control" name="client_secret" type="text" size=60 value="{{config.oh_client_secret}}" placeholder="Enter your Open Humans Client-Secret">
+    <label>Client secret</label> <input class="form-control" name="client_secret" type="text" size=60 value="{{config.oh_client_secret}}" placeholder="Enter your Open Humans Client-Secret" required>
   </div>
   <div class="form-group">
     <label>Activity page URL</label> <input class="form-control" name="activity_page" type="text" size=60 value="{{config.oh_activity_page}}" placeholder="Enter the Open Humans Activity Page URL">


### PR DESCRIPTION
Even if `Required` is mentioned in the Home page, when we go to individual files in *config-oh-settings* and *config-file-settings* pages, if we leave the fields blank, instead of showing any indication or error it was redirecting to the Home page. 

The above problem is addressed, if we click on `Save Updates` without filling the `Required` fields, then it shows an indication to fill the fields rather than redirecting to the Home page.