### PR TITLE
slight improvement to setup

### DIFF
--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -38,6 +38,11 @@
             href="{{ auth_url }}">
               Get started / Login
           </a>
+          {% else %}
+          <a class="btn btn-primary btn-lg"
+            href="{% url 'project-admin:home' %}">
+              Setup your project
+          </a>
           {% endif %}
           <h2>FAQ</h2>
           <div class="panel panel-default">

--- a/main/views.py
+++ b/main/views.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.auth import login, logout
 from django.shortcuts import redirect, render
 from django.contrib import messages
+from django.utils.safestring import mark_safe
 
 import ohapi
 import requests
@@ -159,10 +160,8 @@ def index(request):
     else:
         auth_url = 'http://www.example.com'
     if not proj_config.file_description or not proj_config.oh_client_secret or not proj_config.file_tags or not proj_config.oh_client_id:
-        if request.user.is_authenticated and request.user.username == 'admin':
-            messages.info(request, "Please set up the app.")
-        else:
-            messages.info(request, "Please login to set up the app.")
+        messages.info(request,
+                      mark_safe("<b><a href='/project-admin'>Click here to set up the app.</a></b>"))
     context = {'auth_url': auth_url,
                'index_page': "".join(proj_config.homepage_text)}
     if request.user.is_authenticated and request.user.username != 'admin':


### PR DESCRIPTION
- links the message for logging in
- big 'get started button' becomes 'setup project' button when client-id etc. are missing.