### PR TITLE
Coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,5 @@
 omit =
   */__init__.py
   */tests/*
+  */migration/*
   manage.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+  */__init__.py
+  */tests/*
+  manage.py


### PR DESCRIPTION
I tried to add the migrations, empty `__init__` files and tests to the `.coveragerc` to make sure that these would not be counted towards the test coverage.