### PR TITLE
remove favicon

### DIFF
--- a/main/templates/main/application.html
+++ b/main/templates/main/application.html
@@ -19,8 +19,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     {% load static %}
-    <link rel="icon" type="image/png"
-      href="{% static 'favicon.ico' %}">
 
     <style>
       body {


### PR DESCRIPTION
this was hard to debug :joy: If setting `DEBUG=False` it would only throw error 500's on `heroku` because of the non-existing `favicon`. Now it should actually work w/o `DEBUG=True`. 